### PR TITLE
Update OCM API endpoint URL and default to non-verbose results

### DIFF
--- a/OpenVehicleApp/ovms/OCMSyncHelper.m
+++ b/OpenVehicleApp/ovms/OCMSyncHelper.m
@@ -13,7 +13,7 @@
 #import "EntityName.h"
 
 #define NULL_TO_NIL(obj) ({ __typeof__ (obj) __obj = (obj); __obj == [NSNull null] ? nil : obj; })
-#define BASE_URL @"http://www.openchargemap.org/api/?output=json"
+#define BASE_URL @"http://api.openchargemap.io/v2/poi/?output=json&verbose=false"
 #define SWF(format, args...) [NSString stringWithFormat:format, args]
 
 //#define UPDATE_SEC 120.0


### PR DESCRIPTION
This change updated the OCM API base url for POI queries to include a default non-verbose mode (nulled items are not included in the JSON results). This will need further testing though especially as the V2 api formats dates differently which may or may not be automatically handled in this app code.