### PR TITLE
Add support for TPMS pressure without temperature

### DIFF
--- a/OpenVehicleApp/ovms/ovmsBodyViewController.m
+++ b/OpenVehicleApp/ovms/ovmsBodyViewController.m
@@ -404,6 +404,11 @@
     m_car_wheel_fr_pressure.text = [ovmsAppDelegate myRef].car_tpms_fr_pressure_s;
     m_car_wheel_fr_temp.text = [ovmsAppDelegate myRef].car_tpms_fr_temp_s;
     }
+  else if ([ovmsAppDelegate myRef].car_tpms_fr_pressure_s > 0)
+    {
+    m_car_wheel_fr_pressure.text = [ovmsAppDelegate myRef].car_tpms_fr_pressure_s;
+    m_car_wheel_fr_temp.text = @"";
+    }
   else
     {
     m_car_wheel_fr_pressure.text = @"";
@@ -414,6 +419,11 @@
     {
     m_car_wheel_rr_pressure.text = [ovmsAppDelegate myRef].car_tpms_rr_pressure_s;
     m_car_wheel_rr_temp.text = [ovmsAppDelegate myRef].car_tpms_rr_temp_s;
+    }
+  else if ([ovmsAppDelegate myRef].car_tpms_rr_pressure_s > 0)
+    {
+    m_car_wheel_rr_pressure.text = [ovmsAppDelegate myRef].car_tpms_rr_pressure_s;
+    m_car_wheel_rr_temp.text = @"";
     }
   else
     {
@@ -426,6 +436,11 @@
     m_car_wheel_fl_pressure.text = [ovmsAppDelegate myRef].car_tpms_fl_pressure_s;
     m_car_wheel_fl_temp.text = [ovmsAppDelegate myRef].car_tpms_fl_temp_s;
     }
+  else if ([ovmsAppDelegate myRef].car_tpms_fl_pressure_s > 0)
+    {
+    m_car_wheel_fl_pressure.text = [ovmsAppDelegate myRef].car_tpms_fl_pressure_s;
+    m_car_wheel_fl_temp.text = @"";
+    }
   else
     {
     m_car_wheel_fl_pressure.text = @"";
@@ -436,6 +451,11 @@
     {
     m_car_wheel_rl_pressure.text = [ovmsAppDelegate myRef].car_tpms_rl_pressure_s;
     m_car_wheel_rl_temp.text = [ovmsAppDelegate myRef].car_tpms_rl_temp_s;
+    }
+  else if ([ovmsAppDelegate myRef].car_tpms_rl_pressure_s > 0)
+    {
+    m_car_wheel_rl_pressure.text = [ovmsAppDelegate myRef].car_tpms_rl_pressure_s;
+    m_car_wheel_rl_temp.text = @"";
     }
   else
     {

--- a/OpenVehicleApp/ovms/ovmsBodyViewController.m
+++ b/OpenVehicleApp/ovms/ovmsBodyViewController.m
@@ -399,69 +399,41 @@
     m_car_wheel_rl_temp.textColor = [UIColor whiteColor];
     }
   
-  if ([ovmsAppDelegate myRef].car_tpms_fr_temp > 0)
-    {
+  if ([ovmsAppDelegate myRef].car_tpms_fr_pressure_s > 0)
     m_car_wheel_fr_pressure.text = [ovmsAppDelegate myRef].car_tpms_fr_pressure_s;
-    m_car_wheel_fr_temp.text = [ovmsAppDelegate myRef].car_tpms_fr_temp_s;
-    }
-  else if ([ovmsAppDelegate myRef].car_tpms_fr_pressure_s > 0)
-    {
-    m_car_wheel_fr_pressure.text = [ovmsAppDelegate myRef].car_tpms_fr_pressure_s;
-    m_car_wheel_fr_temp.text = @"";
-    }
   else
-    {
     m_car_wheel_fr_pressure.text = @"";
+  if ([ovmsAppDelegate myRef].car_tpms_fr_temp > 0)
+    m_car_wheel_fr_temp.text = [ovmsAppDelegate myRef].car_tpms_fr_temp_s;
+  else
     m_car_wheel_fr_temp.text = @"";
-    }
 
-  if ([ovmsAppDelegate myRef].car_tpms_rr_temp > 0)
-    {
+  if ([ovmsAppDelegate myRef].car_tpms_rr_pressure_s > 0)
     m_car_wheel_rr_pressure.text = [ovmsAppDelegate myRef].car_tpms_rr_pressure_s;
-    m_car_wheel_rr_temp.text = [ovmsAppDelegate myRef].car_tpms_rr_temp_s;
-    }
-  else if ([ovmsAppDelegate myRef].car_tpms_rr_pressure_s > 0)
-    {
-    m_car_wheel_rr_pressure.text = [ovmsAppDelegate myRef].car_tpms_rr_pressure_s;
-    m_car_wheel_rr_temp.text = @"";
-    }
   else
-    {
     m_car_wheel_rr_pressure.text = @"";
+  if ([ovmsAppDelegate myRef].car_tpms_rr_temp > 0)
+    m_car_wheel_rr_temp.text = [ovmsAppDelegate myRef].car_tpms_rr_temp_s;
+  else
     m_car_wheel_rr_temp.text = @"";
-    }
 
-  if ([ovmsAppDelegate myRef].car_tpms_fl_temp > 0)
-    {
+  if ([ovmsAppDelegate myRef].car_tpms_fl_pressure_s > 0)
     m_car_wheel_fl_pressure.text = [ovmsAppDelegate myRef].car_tpms_fl_pressure_s;
-    m_car_wheel_fl_temp.text = [ovmsAppDelegate myRef].car_tpms_fl_temp_s;
-    }
-  else if ([ovmsAppDelegate myRef].car_tpms_fl_pressure_s > 0)
-    {
-    m_car_wheel_fl_pressure.text = [ovmsAppDelegate myRef].car_tpms_fl_pressure_s;
-    m_car_wheel_fl_temp.text = @"";
-    }
   else
-    {
     m_car_wheel_fl_pressure.text = @"";
-    m_car_wheel_fl_temp.text = @"";
-    }
-  
-  if ([ovmsAppDelegate myRef].car_tpms_rl_temp > 0)
-    {
-    m_car_wheel_rl_pressure.text = [ovmsAppDelegate myRef].car_tpms_rl_pressure_s;
-    m_car_wheel_rl_temp.text = [ovmsAppDelegate myRef].car_tpms_rl_temp_s;
-    }
-  else if ([ovmsAppDelegate myRef].car_tpms_rl_pressure_s > 0)
-    {
-    m_car_wheel_rl_pressure.text = [ovmsAppDelegate myRef].car_tpms_rl_pressure_s;
-    m_car_wheel_rl_temp.text = @"";
-    }
+  if ([ovmsAppDelegate myRef].car_tpms_fl_temp > 0)
+    m_car_wheel_fl_temp.text = [ovmsAppDelegate myRef].car_tpms_fl_temp_s;
   else
-    {
+    m_car_wheel_fl_temp.text = @"";
+
+  if ([ovmsAppDelegate myRef].car_tpms_rl_pressure_s > 0)
+    m_car_wheel_rl_pressure.text = [ovmsAppDelegate myRef].car_tpms_rl_pressure_s;
+  else
     m_car_wheel_rl_pressure.text = @"";
+  if ([ovmsAppDelegate myRef].car_tpms_rl_temp > 0)
+    m_car_wheel_rl_temp.text = [ovmsAppDelegate myRef].car_tpms_rl_temp_s;
+  else
     m_car_wheel_rl_temp.text = @"";
-    }
     
     m_car_aux_battery.text = [NSString stringWithFormat:@"%0.1fV",
                                 [ovmsAppDelegate myRef].car_aux_battery_voltage];

--- a/OpenVehicleApp/ovms/ovmsStatusViewControllerPad.m
+++ b/OpenVehicleApp/ovms/ovmsStatusViewControllerPad.m
@@ -819,69 +819,41 @@
     m_car_wheel_rl_temp.textColor = [UIColor whiteColor];
     }
   
-  if ([ovmsAppDelegate myRef].car_tpms_fr_temp > 0)
-    {
+  if ([ovmsAppDelegate myRef].car_tpms_fr_pressure_s > 0)
     m_car_wheel_fr_pressure.text = [ovmsAppDelegate myRef].car_tpms_fr_pressure_s;
-    m_car_wheel_fr_temp.text = [ovmsAppDelegate myRef].car_tpms_fr_temp_s;
-    }
-  else if ([ovmsAppDelegate myRef].car_tpms_fr_pressure_s > 0)
-    {
-    m_car_wheel_fr_pressure.text = [ovmsAppDelegate myRef].car_tpms_fr_pressure_s;
-    m_car_wheel_fr_temp.text = @"";
-    }
   else
-    {
     m_car_wheel_fr_pressure.text = @"";
+  if ([ovmsAppDelegate myRef].car_tpms_fr_temp > 0)
+    m_car_wheel_fr_temp.text = [ovmsAppDelegate myRef].car_tpms_fr_temp_s;
+  else
     m_car_wheel_fr_temp.text = @"";
-    }
-  
-  if ([ovmsAppDelegate myRef].car_tpms_rr_temp > 0)
-    {
+
+  if ([ovmsAppDelegate myRef].car_tpms_rr_pressure_s > 0)
     m_car_wheel_rr_pressure.text = [ovmsAppDelegate myRef].car_tpms_rr_pressure_s;
-    m_car_wheel_rr_temp.text = [ovmsAppDelegate myRef].car_tpms_rr_temp_s;
-    }
-  else if ([ovmsAppDelegate myRef].car_tpms_rr_pressure_s > 0)
-    {
-    m_car_wheel_rr_pressure.text = [ovmsAppDelegate myRef].car_tpms_rr_pressure_s;
-    m_car_wheel_rr_temp.text = @"";
-    }
   else
-    {
     m_car_wheel_rr_pressure.text = @"";
+  if ([ovmsAppDelegate myRef].car_tpms_rr_temp > 0)
+    m_car_wheel_rr_temp.text = [ovmsAppDelegate myRef].car_tpms_rr_temp_s;
+  else
     m_car_wheel_rr_temp.text = @"";
-    }
-  
-  if ([ovmsAppDelegate myRef].car_tpms_fl_temp > 0)
-    {
+
+  if ([ovmsAppDelegate myRef].car_tpms_fl_pressure_s > 0)
     m_car_wheel_fl_pressure.text = [ovmsAppDelegate myRef].car_tpms_fl_pressure_s;
-    m_car_wheel_fl_temp.text = [ovmsAppDelegate myRef].car_tpms_fl_temp_s;
-    }
-  else if ([ovmsAppDelegate myRef].car_tpms_fl_pressure_s > 0)
-    {
-    m_car_wheel_fl_pressure.text = [ovmsAppDelegate myRef].car_tpms_fl_pressure_s;
-    m_car_wheel_fl_temp.text = @"";
-    }
   else
-    {
     m_car_wheel_fl_pressure.text = @"";
-    m_car_wheel_fl_temp.text = @"";
-    }
-  
-  if ([ovmsAppDelegate myRef].car_tpms_rl_temp > 0)
-    {
-    m_car_wheel_rl_pressure.text = [ovmsAppDelegate myRef].car_tpms_rl_pressure_s;
-    m_car_wheel_rl_temp.text = [ovmsAppDelegate myRef].car_tpms_rl_temp_s;
-    }
-  else if ([ovmsAppDelegate myRef].car_tpms_rl_pressure_s > 0)
-    {
-    m_car_wheel_rl_pressure.text = [ovmsAppDelegate myRef].car_tpms_rl_pressure_s;
-    m_car_wheel_rl_temp.text = @"";
-    }
+  if ([ovmsAppDelegate myRef].car_tpms_fl_temp > 0)
+    m_car_wheel_fl_temp.text = [ovmsAppDelegate myRef].car_tpms_fl_temp_s;
   else
-    {
+    m_car_wheel_fl_temp.text = @"";
+
+  if ([ovmsAppDelegate myRef].car_tpms_rl_pressure_s > 0)
+    m_car_wheel_rl_pressure.text = [ovmsAppDelegate myRef].car_tpms_rl_pressure_s;
+  else
     m_car_wheel_rl_pressure.text = @"";
+  if ([ovmsAppDelegate myRef].car_tpms_rl_temp > 0)
+    m_car_wheel_rl_temp.text = [ovmsAppDelegate myRef].car_tpms_rl_temp_s;
+  else
     m_car_wheel_rl_temp.text = @"";
-    }
 
    m_car_aux_battery.text = [NSString stringWithFormat:@"%0.1fV",
                              [ovmsAppDelegate myRef].car_aux_battery_voltage];

--- a/OpenVehicleApp/ovms/ovmsStatusViewControllerPad.m
+++ b/OpenVehicleApp/ovms/ovmsStatusViewControllerPad.m
@@ -824,6 +824,11 @@
     m_car_wheel_fr_pressure.text = [ovmsAppDelegate myRef].car_tpms_fr_pressure_s;
     m_car_wheel_fr_temp.text = [ovmsAppDelegate myRef].car_tpms_fr_temp_s;
     }
+  else if ([ovmsAppDelegate myRef].car_tpms_fr_pressure_s > 0)
+    {
+    m_car_wheel_fr_pressure.text = [ovmsAppDelegate myRef].car_tpms_fr_pressure_s;
+    m_car_wheel_fr_temp.text = @"";
+    }
   else
     {
     m_car_wheel_fr_pressure.text = @"";
@@ -834,6 +839,11 @@
     {
     m_car_wheel_rr_pressure.text = [ovmsAppDelegate myRef].car_tpms_rr_pressure_s;
     m_car_wheel_rr_temp.text = [ovmsAppDelegate myRef].car_tpms_rr_temp_s;
+    }
+  else if ([ovmsAppDelegate myRef].car_tpms_rr_pressure_s > 0)
+    {
+    m_car_wheel_rr_pressure.text = [ovmsAppDelegate myRef].car_tpms_rr_pressure_s;
+    m_car_wheel_rr_temp.text = @"";
     }
   else
     {
@@ -846,6 +856,11 @@
     m_car_wheel_fl_pressure.text = [ovmsAppDelegate myRef].car_tpms_fl_pressure_s;
     m_car_wheel_fl_temp.text = [ovmsAppDelegate myRef].car_tpms_fl_temp_s;
     }
+  else if ([ovmsAppDelegate myRef].car_tpms_fl_pressure_s > 0)
+    {
+    m_car_wheel_fl_pressure.text = [ovmsAppDelegate myRef].car_tpms_fl_pressure_s;
+    m_car_wheel_fl_temp.text = @"";
+    }
   else
     {
     m_car_wheel_fl_pressure.text = @"";
@@ -856,6 +871,11 @@
     {
     m_car_wheel_rl_pressure.text = [ovmsAppDelegate myRef].car_tpms_rl_pressure_s;
     m_car_wheel_rl_temp.text = [ovmsAppDelegate myRef].car_tpms_rl_temp_s;
+    }
+  else if ([ovmsAppDelegate myRef].car_tpms_rl_pressure_s > 0)
+    {
+    m_car_wheel_rl_pressure.text = [ovmsAppDelegate myRef].car_tpms_rl_pressure_s;
+    m_car_wheel_rl_temp.text = @"";
     }
   else
     {


### PR DESCRIPTION
Until now the app would only display TPMS info when pressure and temperature were both greater than zero. Since not all vehicle modules implement the recovery of both pressure and temperature (and not all cars with TPMS even have hardware support to measure temperature) add code to handle the w/pressure and w/o temperature case.

To take advantage of this change it is necessary to turn off the workaround with:

    `config set server.v2 workaround.ios_tpms_display false`