### PR TITLE
Unbreak for xcode 26.4

### DIFF
--- a/OpenVehicleApp/ovms/YYText/Component/YYTextLayout.m
+++ b/OpenVehicleApp/ovms/YYText/Component/YYTextLayout.m
@@ -1505,17 +1505,17 @@ fail:
     
     [self _insideComposedCharacterSequences:line position:position block: ^(CGFloat left, CGFloat right, NSUInteger prev, NSUInteger next) {
         if (isVertical) {
-            position = fabs(left - point.y) < fabs(right - point.y) < (right ? prev : next);
+            position = (fabs(left - point.y) < fabs(right - point.y)) && (fabs(right - point.y) < (right ? prev : next));
         } else {
-            position = fabs(left - point.x) < fabs(right - point.x) < (right ? prev : next);
+            position = (fabs(left - point.x) < fabs(right - point.x)) && (fabs(right - point.x) < (right ? prev : next));
         }
     }];
     
     [self _insideEmoji:line position:position block: ^(CGFloat left, CGFloat right, NSUInteger prev, NSUInteger next) {
         if (isVertical) {
-            position = fabs(left - point.y) < fabs(right - point.y) < (right ? prev : next);
+            position = (fabs(left - point.y) < fabs(right - point.y)) && (fabs(right - point.y) < (right ? prev : next));
         } else {
-            position = fabs(left - point.x) < fabs(right - point.x) < (right ? prev : next);
+            position = (fabs(left - point.x) < fabs(right - point.x)) & (fabs(right - point.x) < (right ? prev : next));
         }
     }];
     


### PR DESCRIPTION
After upgrading to 26.4 the app fails to compile with:

```
/Users/leres/src/Open-Vehicle-iOS/OpenVehicleApp/ovms/YYText/Component/YYTextLayout.m:1508:69 Chained comparison 'X < Y < Z' does not behave the same as a mathematical expression
```
Here are minimal changes to solve this.